### PR TITLE
Bug fixing

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -46,6 +46,7 @@ gem 'bootsnap', require: false
 
 # Use Sass to process CSS
 # gem "sassc-rails"
+gem 'pry'
 
 # Use Active Storage variants [https://guides.rubyonrails.org/active_storage_overview.html#transforming-images]
 # gem "image_processing", "~> 1.2"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -71,6 +71,7 @@ GEM
     bootsnap (1.15.0)
       msgpack (~> 1.2)
     builder (3.2.4)
+    coderay (1.1.3)
     concurrent-ruby (1.1.10)
     crass (1.0.6)
     debug (1.6.3)
@@ -107,9 +108,14 @@ GEM
     nio4r (2.5.8)
     nokogiri (1.13.9-aarch64-linux)
       racc (~> 1.4)
+    nokogiri (1.13.9-x86_64-linux)
+      racc (~> 1.4)
     parallel (1.22.1)
     parser (3.1.3.0)
       ast (~> 2.4.1)
+    pry (0.14.1)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
     puma (5.6.5)
       nio4r (~> 2.0)
     racc (1.6.0)
@@ -192,6 +198,7 @@ GEM
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
     sqlite3 (1.5.4-aarch64-linux)
+    sqlite3 (1.5.4-x86_64-linux)
     stimulus-rails (1.2.1)
       railties (>= 6.0.0)
     thor (1.2.1)
@@ -215,12 +222,14 @@ GEM
 
 PLATFORMS
   aarch64-linux
+  x86_64-linux
 
 DEPENDENCIES
   bootsnap
   debug
   faker
   importmap-rails
+  pry
   puma (~> 5.0)
   rack-mini-profiler
   rails (~> 7.0.4)

--- a/app/models/applicant.rb
+++ b/app/models/applicant.rb
@@ -12,7 +12,4 @@ class Applicant < ApplicationRecord
 
   enum status: { applied: 0, initial_review: 1, more_information_required: 2, declined: 3, approved: 4 }
 
-  def project_title
-    'Project'
-  end
 end

--- a/app/views/applicants/index.html.erb
+++ b/app/views/applicants/index.html.erb
@@ -19,7 +19,7 @@
   <% @applicants.each do |applicant| %>
     <tr>
       <td><%= applicant.name %></td>
-      <td><%= applicant.project_title %></td>
+      <td><%= applicant.project.title %></td>
       <td><%= applicant.status.titleize %></td>
       <td><%= link_to "Show this applicant", applicant %></td>
     </tr>

--- a/spec/views/applicants/index.html.erb_spec.rb
+++ b/spec/views/applicants/index.html.erb_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe 'applicants/index' do
   let(:project) do
     Project.create!(
       payment_date: Date.current + 1.month,
-      title: 'Project',
+      title: applicant.project.title,
       fund:
     )
   end


### PR DESCRIPTION
Fixed the bug on the applicant page.
Explanation:
The bug could have been avoided by taking advantage of active resource association between applicant and project resources where we get the `project` method available for use by applicant as a caller as in `applicant.project.title`
The `belong_to : project ` available in the applicant model give us this powerful advantage in our case here. 